### PR TITLE
tweak: smarter gcalendar syncs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +126,28 @@ dependencies = [
  "time",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c39203181991a7dd4343b8005bd804e7a9a37afb8ac070e43771e8c820bbde"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf 0.11.1",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f509c3a87b33437b05e2458750a0700e5bdd6956176773e6c7d6dd15a283a0c"
+dependencies = [
+ "parse-zoneinfo",
+ "phf 0.11.1",
+ "phf_codegen 0.11.1",
 ]
 
 [[package]]
@@ -508,6 +539,7 @@ dependencies = [
  "log",
  "oauth2",
  "reqwest",
+ "rrule",
  "serde",
  "serde_json",
  "strum",
@@ -987,6 +1019,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,6 +1054,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
+dependencies = [
+ "phf_shared 0.11.1",
+]
+
+[[package]]
 name = "phf_codegen"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1083,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_codegen"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56ac890c5e3ca598bbdeaa99964edb5b0258a583a9eb6ef4e89fc85d9224770"
+dependencies = [
+ "phf_generator 0.11.1",
+ "phf_shared 0.11.1",
+]
+
+[[package]]
 name = "phf_generator"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,6 +1109,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
+dependencies = [
+ "phf_shared 0.11.1",
  "rand 0.8.5",
 ]
 
@@ -1082,6 +1152,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
+dependencies = [
+ "siphasher",
+ "uncased",
 ]
 
 [[package]]
@@ -1249,6 +1329,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1312,6 +1409,20 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rrule"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "822efdcd86c668b92c5ddc4c08906b731d184feb3e595575924737495ae928a7"
+dependencies = [
+ "chrono",
+ "chrono-tz",
+ "lazy_static",
+ "log",
+ "regex",
+ "thiserror",
 ]
 
 [[package]]
@@ -1823,6 +1934,15 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "uncased"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/crates/google/Cargo.toml
+++ b/crates/google/Cargo.toml
@@ -10,10 +10,11 @@ anyhow = "1.0"
 async-trait = "0.1"
 auth_core = { path = "../auth_core" }
 bytes = "1.2"
-chrono = "0.4"
+chrono = "0.4.23"
 log = "0.4"
 oauth2 = "4.2.3"
 reqwest = { version = "0.11", features = ["json"] }
+rrule = "0.10.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 strum = "0.24"

--- a/crates/google/examples/gcalendar.rs
+++ b/crates/google/examples/gcalendar.rs
@@ -1,5 +1,4 @@
 use dotenv_codegen::dotenv;
-
 use libauth::helpers::load_credentials;
 use libgoog::{types::AuthScope, ClientType, GoogClient};
 
@@ -43,11 +42,12 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let last_month = chrono::Utc::now() - chrono::Duration::days(30);
+    let future_month = chrono::Utc::now() + chrono::Duration::days(30);
 
     println!("\n------------------------------");
     println!("PRIMARY CALENDAR");
     let primary_events = client
-        .list_calendar_events("primary", Some(last_month), None)
+        .list_calendar_events("primary", Some(last_month), Some(future_month), None)
         .await?;
     for event in primary_events.items.iter().take(10) {
         // Skip recurring dates that don't have a next recurrence within our time
@@ -80,7 +80,7 @@ async fn main() -> anyhow::Result<()> {
     for cal in cals.items.iter().take(5) {
         println!("\nCALENDAR: {} ({})", cal.summary, cal.id);
         if let Ok(events) = client
-            .list_calendar_events(&cal.id, Some(last_month), None)
+            .list_calendar_events(&cal.id, Some(last_month), Some(future_month), None)
             .await
         {
             for event in events.items.iter().take(5) {

--- a/crates/google/src/lib.rs
+++ b/crates/google/src/lib.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use chrono::DateTime;
+use chrono::{DateTime, Utc};
 use libauth::OAuthParams;
 use std::str::FromStr;
 
@@ -221,7 +221,8 @@ impl GoogClient {
     pub async fn list_calendar_events(
         &mut self,
         calendar_id: &str,
-        last_modified: Option<DateTime<chrono::Utc>>,
+        after: Option<DateTime<Utc>>,
+        before: Option<DateTime<Utc>>,
         next_page: Option<String>,
     ) -> Result<ListCalendarEventsResponse, ApiError> {
         let mut endpoint = self.endpoint.to_string();
@@ -234,8 +235,12 @@ impl GoogClient {
         };
 
         params.push(("orderBy".to_string(), "updated".to_string()));
-        if let Some(last_mod) = last_modified {
-            params.push(("timeMin".into(), last_mod.to_rfc3339()));
+        if let Some(after) = after {
+            params.push(("timeMin".into(), after.to_rfc3339()));
+        }
+
+        if let Some(before) = before {
+            params.push(("timeMax".into(), before.to_rfc3339()));
         }
 
         self.call_json(&endpoint, &params).await

--- a/crates/google/src/lib.rs
+++ b/crates/google/src/lib.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use chrono::DateTime;
 use libauth::OAuthParams;
 use std::str::FromStr;
 
@@ -220,6 +221,7 @@ impl GoogClient {
     pub async fn list_calendar_events(
         &mut self,
         calendar_id: &str,
+        last_modified: Option<DateTime<chrono::Utc>>,
         next_page: Option<String>,
     ) -> Result<ListCalendarEventsResponse, ApiError> {
         let mut endpoint = self.endpoint.to_string();
@@ -231,8 +233,10 @@ impl GoogClient {
             Vec::new()
         };
 
-        params.push(("orderBy".to_string(), "startTime".to_string()));
-        params.push(("singleEvents".to_string(), "true".to_string()));
+        params.push(("orderBy".to_string(), "updated".to_string()));
+        if let Some(last_mod) = last_modified {
+            params.push(("timeMin".into(), last_mod.to_rfc3339()));
+        }
 
         self.call_json(&endpoint, &params).await
     }

--- a/crates/google/src/types.rs
+++ b/crates/google/src/types.rs
@@ -1,4 +1,9 @@
-use chrono::{DateTime, Utc};
+use std::str::FromStr;
+
+use anyhow::anyhow;
+use chrono::{DateTime, NaiveDate, Utc};
+pub use rrule::Tz;
+use rrule::{RRule, RRuleSet};
 use serde::{Deserialize, Serialize};
 use strum_macros::{AsRefStr, Display, EnumString};
 
@@ -49,6 +54,63 @@ pub struct CalendarEvent {
     pub end: CalendarTime,
     pub recurrence: Vec<String>,
     pub recurring_event_id: String,
+}
+
+impl CalendarEvent {
+    pub fn is_recurring(&self) -> bool {
+        !self.recurrence.is_empty()
+    }
+
+    pub fn next_recurrence(&self) -> Option<DateTime<Tz>> {
+        self.list_recurrences(1, None, None)
+            .map(|x| x.get(0).map(|x| x.to_owned()))
+            .unwrap_or_default()
+    }
+
+    /// If this is a recurring event, this will return the next <num_recurrences>
+    /// after the date specified. If <after> is set to None, the current date and time
+    /// will be used.
+    pub fn list_recurrences(
+        &self,
+        num_recurrences: u16,
+        after: Option<DateTime<Utc>>,
+        before: Option<DateTime<Utc>>,
+    ) -> anyhow::Result<Vec<DateTime<Tz>>> {
+        let start = if let Some(date) = self.start.date_time {
+            date
+        } else if let Ok(date) = NaiveDate::parse_from_str(&self.start.date, "%Y-%m-%d") {
+            let date = date.and_hms_opt(0, 0, 0).expect("Invalid hms");
+            DateTime::from_utc(date, Utc)
+        } else {
+            return Err(anyhow!("Invalid date"));
+        };
+
+        // Adjust the timezone to UTC
+        let start = start.with_timezone(&Tz::UTC);
+        let mut rrules = RRuleSet::new(start);
+        for recur in self.recurrence.iter() {
+            if let Ok(recur) = RRule::from_str(recur) {
+                let validated = recur.validate(start)?;
+                rrules = rrules.rrule(validated);
+            }
+        }
+
+        // Only show dates after <after> or today by default
+        let after = after.unwrap_or(Utc::now());
+        // By default, if <before> is not set, only show dates 1 year in advance
+        let before = before.unwrap_or(after + chrono::Duration::days(365));
+        rrules = rrules
+            .after(after.with_timezone(&Tz::UTC))
+            .before(before.with_timezone(&Tz::UTC));
+
+        let (result, _) = rrules.all(num_recurrences);
+        let result = result
+            .iter()
+            .map(|x| x.with_timezone(&Tz::UTC))
+            .collect::<Vec<_>>();
+
+        Ok(result)
+    }
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -171,4 +233,75 @@ pub enum FileType {
 #[serde(default, rename_all = "camelCase")]
 pub struct GoogUser {
     pub email: String,
+}
+
+#[cfg(test)]
+mod test {
+    use crate::types::{CalendarEvent, CalendarTime};
+    use chrono::TimeZone;
+
+    #[test]
+    fn test_next_recurrence_yearly() {
+        let event = CalendarEvent {
+            start: CalendarTime {
+                date: "2019-11-12".into(),
+                date_time: None,
+                time_zone: "America/Los_Angeles".into(),
+            },
+            recurrence: vec!["RRULE:FREQ=YEARLY;INTERVAL=1".into()],
+            ..Default::default()
+        };
+
+        let today = chrono::Utc.with_ymd_and_hms(2023, 2, 1, 0, 0, 0).unwrap();
+        let recurrences = event
+            .list_recurrences(1, Some(today), None)
+            .expect("Unable to get next recurrences");
+        assert_eq!(recurrences.len(), 1);
+
+        let next = event.next_recurrence();
+        assert!(next.is_some());
+        assert_eq!(next.unwrap().to_rfc3339(), "2023-11-12T00:00:00+00:00");
+    }
+
+    #[test]
+    fn test_next_recurrence_none() {
+        let event = CalendarEvent {
+            start: CalendarTime {
+                date: "".into(),
+                date_time: Some("2007-10-01T13:00:00-07:00".parse().expect("Invalid date")),
+                time_zone: "America/Los_Angeles".into(),
+            },
+            recurrence: vec!["RRULE:FREQ=WEEKLY;WKST=SU;COUNT=30;INTERVAL=1;BYDAY=MO,WE,FR".into()],
+            ..Default::default()
+        };
+
+        let recurrences = event
+            .list_recurrences(5, None, None)
+            .expect("Unable to get next recurrences");
+        assert_eq!(recurrences.len(), 0);
+    }
+
+    #[test]
+    fn test_next_recurrence_until() {
+        let datetime = chrono::DateTime::parse_from_rfc3339("2023-01-03T09:30:00-08:00").unwrap();
+
+        let event = CalendarEvent {
+            start: CalendarTime {
+                date: "".into(),
+                date_time: Some(datetime.with_timezone(&chrono::Utc)),
+                time_zone: "America/Los_Angeles".into(),
+            },
+            recurrence: vec![
+                "RRULE:FREQ=WEEKLY;WKST=SU;UNTIL=20230308T000000Z;INTERVAL=3;BYDAY=TU".into(),
+            ],
+            ..Default::default()
+        };
+
+        let recurrences = event
+            .list_recurrences(5, None, None)
+            .expect("Unable to get next recurrences");
+
+        dbg!(&recurrences);
+        assert_eq!(recurrences.len(), 1);
+    }
 }

--- a/crates/google/src/types.rs
+++ b/crates/google/src/types.rs
@@ -292,7 +292,7 @@ mod test {
                 time_zone: "America/Los_Angeles".into(),
             },
             recurrence: vec![
-                "RRULE:FREQ=WEEKLY;WKST=SU;UNTIL=20230308T000000Z;INTERVAL=3;BYDAY=TU".into(),
+                "RRULE:FREQ=WEEKLY;WKST=SU;UNTIL=20230307T180000Z;INTERVAL=3;BYDAY=TU".into(),
             ],
             ..Default::default()
         };

--- a/crates/google/src/types.rs
+++ b/crates/google/src/types.rs
@@ -61,7 +61,7 @@ impl CalendarEvent {
         !self.recurrence.is_empty()
     }
 
-    pub fn next_recurrence(&self) -> Option<DateTime<Tz>> {
+    pub fn next_recurrence(&self) -> Option<DateTime<Utc>> {
         self.list_recurrences(1, None, None)
             .map(|x| x.get(0).map(|x| x.to_owned()))
             .unwrap_or_default()
@@ -75,7 +75,7 @@ impl CalendarEvent {
         num_recurrences: u16,
         after: Option<DateTime<Utc>>,
         before: Option<DateTime<Utc>>,
-    ) -> anyhow::Result<Vec<DateTime<Tz>>> {
+    ) -> anyhow::Result<Vec<DateTime<Utc>>> {
         let start = if let Some(date) = self.start.date_time {
             date
         } else if let Ok(date) = NaiveDate::parse_from_str(&self.start.date, "%Y-%m-%d") {
@@ -106,7 +106,7 @@ impl CalendarEvent {
         let (result, _) = rrules.all(num_recurrences);
         let result = result
             .iter()
-            .map(|x| x.with_timezone(&Tz::UTC))
+            .map(|x| x.with_timezone(&Utc))
             .collect::<Vec<_>>();
 
         Ok(result)


### PR DESCRIPTION
- [x] Treat recurring events as a single item from the API when syncing
    - [x] Use the rules to generate the next recurrence within the interested time period
- [x] Time box events we care about, 1 year in the past & 3 months into the future.